### PR TITLE
container options

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -49,8 +49,8 @@ func parseConf() (conf *Conf, err error) {
 	return &parsedConf, nil
 }
 
-func createDocker(args *Args, conf *Conf) (options *recreate.DockerOptions) {
-	return &recreate.DockerOptions{
+func createOptions(args *Args, conf *Conf) recreate.DockerOptions {
+	return recreate.DockerOptions{
 		PullImage:       args.pullImage,
 		DeleteContainer: args.deleteContainer,
 		Registries:      conf.Registries}
@@ -71,11 +71,14 @@ func main() {
 	conf, _ := parseConf()
 	checkError(err)
 
-	recreation, err := recreate.Recreate(
+	context, err := recreate.NewContext(createOptions(&args, conf))
+	checkError(err)
+
+	recreation, err := context.Recreate(
 		args.containerID,
 		args.imageTag,
 		&recreate.ContainerOptions{},
-		createDocker(&args, conf))
+	)
 	checkError(err)
 
 	fmt.Printf(

--- a/cli/main.go
+++ b/cli/main.go
@@ -49,7 +49,7 @@ func parseConf() (conf *Conf, err error) {
 	return &parsedConf, nil
 }
 
-func createOptions(args *Args, conf *Conf) (options *recreate.DockerOptions) {
+func createDocker(args *Args, conf *Conf) (options *recreate.DockerOptions) {
 	return &recreate.DockerOptions{
 		PullImage:       args.pullImage,
 		DeleteContainer: args.deleteContainer,
@@ -74,7 +74,8 @@ func main() {
 	recreation, err := recreate.Recreate(
 		args.containerID,
 		args.imageTag,
-		createOptions(&args, conf))
+		&recreate.ContainerOptions{},
+		createDocker(&args, conf))
 	checkError(err)
 
 	fmt.Printf(

--- a/container.go
+++ b/container.go
@@ -67,3 +67,14 @@ func cloneContainerOptions(
 
 	return options, err
 }
+
+func mergeContainerEnv(options docker.CreateContainerOptions, env map[string]string) []string {
+	var variables []string
+	copy(variables, options.Config.Env)
+
+	for k, v := range env {
+		variables = append(variables, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return variables
+}

--- a/container.go
+++ b/container.go
@@ -69,7 +69,7 @@ func cloneContainerOptions(
 }
 
 func mergeContainerEnv(options docker.CreateContainerOptions, env map[string]string) []string {
-	var variables []string
+	variables := make([]string, len(options.Config.Env))
 	copy(variables, options.Config.Env)
 
 	for k, v := range env {

--- a/container_test.go
+++ b/container_test.go
@@ -1,0 +1,52 @@
+package recreate
+
+import (
+	"github.com/fsouza/go-dockerclient"
+	"testing"
+)
+
+// <https://stackoverflow.com/a/15312097>
+func testEquality(a []string, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestMergeContainerEnv(t *testing.T) {
+	env := make(map[string]string)
+	env["FOO"] = "BAR"
+	env["BAR"] = "baz123"
+
+	config := docker.CreateContainerOptions{
+		Config: &docker.Config{
+			Env: []string{"BAZ=bar"},
+		},
+	}
+
+	expected := []string{
+		"BAZ=bar",
+		"FOO=BAR",
+		"BAR=baz123",
+	}
+
+	received := mergeContainerEnv(config, env)
+
+	if !testEquality(expected, received) {
+		t.Errorf("Merged environenment variables do not equal:\nExpected: %v\nReceived: %v\n",
+			expected,
+			received,
+		)
+	}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -26,8 +26,8 @@ func testEquality(a []string, b []string) bool {
 
 func TestMergeContainerEnv(t *testing.T) {
 	env := make(map[string]string)
-	env["FOO"] = "BAR"
 	env["BAR"] = "baz123"
+	env["FOO"] = "BAR"
 
 	config := docker.CreateContainerOptions{
 		Config: &docker.Config{
@@ -37,8 +37,8 @@ func TestMergeContainerEnv(t *testing.T) {
 
 	expected := []string{
 		"BAZ=bar",
-		"FOO=BAR",
 		"BAR=baz123",
+		"FOO=BAR",
 	}
 
 	received := mergeContainerEnv(config, env)

--- a/context.go
+++ b/context.go
@@ -1,0 +1,46 @@
+package recreate
+
+import (
+	"github.com/fsouza/go-dockerclient"
+)
+
+// DockerOptions describe additional options for pulling and creating the container
+type DockerOptions struct {
+	PullImage       bool
+	DeleteContainer bool
+	Registries      []RegistryConf
+}
+
+// Context describes the context needed for managing tokens
+type Context struct {
+	client  *docker.Client
+	options DockerOptions
+}
+
+// NewContext creates a new recreation context with the default Docker environment
+func NewContext(options DockerOptions) (context Context, err error) {
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		return Context{}, err
+	}
+
+	return NewContextWithClient(options, client), nil
+}
+
+// NewContextWithEndpoint creates a new recreation context with a specified Docker endpoint
+func NewContextWithEndpoint(options DockerOptions, endpoint string) (context Context, err error) {
+	client, err := docker.NewClient(endpoint)
+	if err != nil {
+		return Context{}, err
+	}
+
+	return NewContextWithClient(options, client), nil
+}
+
+// NewContextWithClient creates a new recreation context with an existing Docker client
+func NewContextWithClient(options DockerOptions, client *docker.Client) Context {
+	return Context{
+		client:  client,
+		options: options,
+	}
+}

--- a/recreate.go
+++ b/recreate.go
@@ -10,67 +10,20 @@ type Recreation struct {
 	NewContainerID      string `json:"newContainerID"`
 }
 
-// DockerOptions describe additional options for pulling and creating the container
-type DockerOptions struct {
-	PullImage       bool
-	DeleteContainer bool
-	Registries      []RegistryConf
-}
-
 // ContainerOptions describe additional options applied to the container
 type ContainerOptions struct {
+	Env map[string]string
 }
 
-// Recreate a container within the default Docker environment
-func Recreate(
+// Recreate recreates a container within a given context
+func (c Context) Recreate(
 	containerID string,
 	imageTag string,
 	containerOptions *ContainerOptions,
-	dockerOptions *DockerOptions) (
-	recreation *Recreation,
-	err error) {
-	client, err := docker.NewClientFromEnv()
-	if err != nil {
-		return nil, err
-	}
+) (recreation *Recreation, err error) {
+	client := c.client
+	dockerOptions := c.options
 
-	recreation, err = RecreateWithClient(containerID, imageTag, containerOptions, dockerOptions, client)
-	if err != nil {
-		return nil, err
-	}
-
-	return recreation, nil
-}
-
-// RecreateWithEndpoint a container on a specified endpoint
-func RecreateWithEndpoint(
-	containerID string,
-	imageTag string,
-	containerOptions *ContainerOptions,
-	dockerOptions *DockerOptions,
-	endpoint string) (
-	recreation *Recreation,
-	err error) {
-	client, err := docker.NewClient(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	recreation, err = RecreateWithClient(containerID, imageTag, containerOptions, dockerOptions, client)
-	if err != nil {
-		return nil, err
-	}
-
-	return recreation, nil
-}
-
-// RecreateWithClient recreates a container with a given Docker client
-func RecreateWithClient(
-	containerID string,
-	imageTag string,
-	containerOptions *ContainerOptions,
-	dockerOptions *DockerOptions,
-	client *docker.Client) (recreation *Recreation, err error) {
 	previousContainer, err := client.InspectContainer(containerID)
 	if err != nil {
 		return nil, err

--- a/recreate.go
+++ b/recreate.go
@@ -62,6 +62,7 @@ func (c Context) Recreate(
 		return nil, err
 	}
 
+	cloneOptions.Config.Env = mergeContainerEnv(cloneOptions, containerOptions.Env)
 	newContainer, err := client.CreateContainer(cloneOptions)
 
 	if err != nil {


### PR DESCRIPTION
container options will, as an additional parameter to `Recreate`, enable to specify new environment variables ~and networks~ that are going to be applied to the freshly-created container.

addresses #8.